### PR TITLE
Fix on importing OA events

### DIFF
--- a/pro/inc/class-import-oa.php
+++ b/pro/inc/class-import-oa.php
@@ -241,6 +241,9 @@ class Import_OA {
 				);
 				if ( ! empty( $openagenda_events ) ) {
 					$id = $openagenda_events[0]->ID;
+				} else {
+					// Set ID as NULL, so that it doesn't take the previous value
+					$id = null;
 				}
 
 				// Date Formating


### PR DESCRIPTION
Bug: When manually running the import from Open Agenda, the newly added events are not being imported when there are already some events present in the database.
The cause of this is that when walking through the array of events, when an event is found in the database, the post ID is stored in a $id variable. Then, if the following event is not found, $id should be set to null, otherwise it keeps the previous value.