### PR TITLE
Prevent fatal error from misinterpreting time input format

### DIFF
--- a/inc/class-the-event-calendar.php
+++ b/inc/class-the-event-calendar.php
@@ -508,11 +508,10 @@ class The_Event_Calendar {
 			$start_date = $start->format( 'U' );
 			$end_date   = $end->format( 'U' );
 			$diff       = intval( floor( ( $end_date - $start_date ) / 86400 ) );
-			$end        = DateTime::createFromFormat( $format . ' H:i', $_POST['EventStartDate'] . ' ' .
-                                                               $_POST['EventEndTime'] );
-			$start      = DateTime::createFromFormat( $format . ' H:i', $_POST['EventStartDate'] . ' ' . $_POST['EventStartTime'] );
-			$end        = $end->format( 'U' );
-			$start      = $start->format( 'U' );
+			$end        = DateTime::createFromFormat( $format . ' g:ia', $_POST['EventStartDate'] . ' ' . $_POST['EventEndTime'] );
+			$start      = DateTime::createFromFormat( $format . ' g:ia', $_POST['EventStartDate'] . ' ' . $_POST['EventStartTime'] );
+			$end        = $end ? $end->format( 'U' ) : 0;
+			$start      = $start ? $start->format( 'U' ) : 0;
 
 			$i = 0;
 			while ( $i <= $diff ) {


### PR DESCRIPTION
When saving events, there is a fatal error coming up at inc/class-the-event-calendar.php:514.
DateTime::createFromFormat is returning false, so when trying to use the DateTime object it crashes.
The reason is that the date input format is "g:ia", while the expected format is "H:i".
I updated the expected format to "g:ia" and added a safety check for the DateTime object to not be false, so that in case the date is not parsed correctly, it will be interpreted as 0 and does not cause a crash.